### PR TITLE
Makes IsString (List Char) similar to base's IsString [Char]

### DIFF
--- a/src/Course/List.hs
+++ b/src/Course/List.hs
@@ -659,7 +659,8 @@ readFloat ::
 readFloat =
   mapOptional fst . readFloats
 
-instance IsString (List Char) where
+instance (a ~ Char) => IsString (List a) where
+  -- Per https://hackage.haskell.org/package/base-4.14.1.0/docs/src/Data.String.html#line-43
   fromString =
     listh
 


### PR DESCRIPTION
Prevents `"AA" ++ "AA"` causing 

λ> "AA" ++ "AA"
```
<interactive>:74:1-12: error:
    • Non type-variable argument in the constraint: IsString (List a)
      (Use FlexibleContexts to permit this)
    • When checking the inferred type
        it :: forall {a}. IsString (List a) => List a
```