### PR TITLE
Rename vars for clarity

### DIFF
--- a/src/Course/List.hs
+++ b/src/Course/List.hs
@@ -469,9 +469,9 @@ unfoldr ::
   (a -> Optional (b, a))
   -> a
   -> List b
-unfoldr f b  =
-  case f b of
-    Full (a, z) -> a :. unfoldr f z
+unfoldr f a  =
+  case f a of
+    Full (b, a') -> b :. unfoldr f a'
     Empty -> Nil
 
 lines ::


### PR DESCRIPTION
This is not too important, but for me personally, the original names were really confusing because the type variables and the variables had conflicting names.