### PR TITLE
firstRepeat doctest example

### DIFF
--- a/src/Course/State.hs
+++ b/src/Course/State.hs
@@ -150,6 +150,9 @@ findM =
 --
 -- /Tip:/ Use `findM` and `State` with a @Data.Set#Set@.
 --
+-- >>> firstRepeat $ 1 :. 2 :. 0 :. 9 :. 2 :. 1 :. Nil
+-- Full 2
+--
 -- prop> \xs -> case firstRepeat xs of Empty -> let xs' = hlist xs in nub xs' == xs'; Full x -> length (filter (== x) xs) > 1
 -- prop> \xs -> case firstRepeat xs of Empty -> True; Full x -> let (l, (rx :. rs)) = span (/= x) xs in let (l2, r2) = span (/= x) rs in let l3 = hlist (l ++ (rx :. Nil) ++ l2) in nub l3 == l3
 firstRepeat ::


### PR DESCRIPTION
Add an example/doctest for firstRepeat which demonstrates
the expected behavior.

I thought this would be useful because I was initially
confused on the implementation. For a bit I thought
`firstRepeat` was supposed to find the first element
which has a repeat element somewhere in the list.
The example given demonstrates the important
distinction that we aren't looking for the first element
that has another of itself in the list, but that we're
looking for the first repeat element.