### PR TITLE
Comonad and Contravariant functions not in scope in ghci

### DIFF
--- a/src/Course.hs
+++ b/src/Course.hs
@@ -7,8 +7,9 @@ import Course.Alternative as X
 import Course.Anagrams as X
 import Course.Applicative as X
 import Course.Cheque as X
-import Course.Comonad as X (Comonad (..))
+import Course.Comonad as X
 import Course.Compose as X
+import Course.Contravariant as X
 import Course.Core as X
 import Course.ExactlyOne as X
 import Course.Extend as X


### PR DESCRIPTION
Comonad and Contravariant functions aren't available in ghci when I run off the current master branch. After making the following changes the functions are available.

Comonad error:

```
>> (+10) <$$> ExactlyOne 7

<interactive>:42:7: error:
    • Variable not in scope: (<$$>) :: (a0 -> a0) -> ExactlyOne a1 -> t
    • Perhaps you meant ‘<$>’ (imported from Course.Functor)
```


Contravariant errors:

```
>> runPredicate ((+1) >$< Predicate even) 2

<interactive>:6:1: error:
    Variable not in scope: runPredicate :: t0 -> t2 -> t

<interactive>:6:20: error:
    • Variable not in scope: (>$<) :: (a1 -> a1) -> t1 -> t0
    • Perhaps you meant ‘>$>’ (imported from Course.ListZipper)

<interactive>:6:24: error:
    Data constructor not in scope: Predicate :: (a0 -> Bool) -> t1
```