### PR TITLE
add Contravariant Test

### DIFF
--- a/src/Test/ContravariantTest.hs
+++ b/src/Test/ContravariantTest.hs
@@ -63,7 +63,7 @@ swappedArrowTest =
 ignoreTest :: TestTree
 ignoreTest =
   testGroup "Ignore" [
-    testProperty "Ignore input value always odd" $ \x ->
+    testProperty "Ignore input value, always odd" $ \x ->
       runPredicate (3 >$ Predicate odd) (x :: Integer)
   , testProperty "Ignore input value, always even" $ \x ->
       not (runPredicate (4 >$ Predicate odd) (x :: Integer))

--- a/src/Test/ContravariantTest.hs
+++ b/src/Test/ContravariantTest.hs
@@ -1,0 +1,70 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Test.ContravariantTest (
+  -- * Tests
+    test_Contravariant
+  , predicateTest
+  , comparisonTest
+  , swappedArrowTest
+  , ignoreTest
+
+  -- * Runner
+  , test
+  ) where
+
+import           Test.Framework  (TestTree, testCase, testGroup, test, (@?=), testProperty)
+
+import           Course.Core
+import           Course.Contravariant ((>$<), (>$), Predicate (Predicate), runPredicate,
+                                       Comparison (Comparison), runComparison,
+                                       SwappedArrow (SwappedArrow), runSwappedArrow)
+import           Course.List (length, (++), List (Nil, (:.)), listh)
+
+test_Contravariant :: TestTree
+test_Contravariant =
+  testGroup "Contravariant" [
+    predicateTest
+  , comparisonTest
+  , swappedArrowTest
+  , ignoreTest
+  ]
+
+
+predicateTest :: TestTree
+predicateTest =
+  testGroup "Predicate" [
+    testCase "even" $
+      runPredicate ((+1) >$< Predicate even) 2 @?= False
+  , testCase "even length" $
+      runPredicate (length >$< Predicate even) (1 :. 2 :. Nil) @?= True
+  ]
+
+comparisonTest :: TestTree
+comparisonTest =
+  testGroup "Comparison" [
+    testCase "show" $
+      runComparison (show >$< Comparison compare) 2 12 @?= GT
+  , testCase "id" $
+      runComparison (id >$< Comparison compare) 2 12 @?= LT
+  , testCase "length" $
+      runComparison (length >$< Comparison compare) ('a' :. Nil) ('b' :. Nil) @?= EQ
+  ]
+
+swappedArrowTest :: TestTree
+swappedArrowTest =
+  testGroup "SwappedArrow" [
+    testCase "length" $
+      runSwappedArrow (length >$< SwappedArrow (+10)) (listh "hello") @?= 15
+  , testCase "id" $
+      runSwappedArrow (id >$< SwappedArrow (++ listh " world")) (listh "hello") @?= listh "hello world"
+  ]
+
+ignoreTest :: TestTree
+ignoreTest =
+  testGroup "Ignore" [
+    testProperty "Ignore input value always odd" $ \x ->
+      runPredicate (3 >$ Predicate odd) (x :: Integer)
+  , testProperty "Ignore input value, always even" $ \x ->
+      not (runPredicate (4 >$ Predicate odd) (x :: Integer))
+  ]

--- a/src/Test/Loader.hs
+++ b/src/Test/Loader.hs
@@ -19,6 +19,7 @@ module Test.Loader
   , test_MoreParser
   , test_JsonParser
   , test_Cheque
+  , test_Contravariant
 
   , test
   , allTests
@@ -28,6 +29,7 @@ module Test.Loader
 import Test.ApplicativeTest (test_Applicative)
 import Test.ChequeTest (test_Cheque)
 import Test.ComonadTest (test_Comonad)
+import Test.ContravariantTest (test_Contravariant)
 import Test.ExtendTest (test_Extend)
 import Test.FunctorTest (test_Functor)
 import Test.JsonParserTest (test_JsonParser)
@@ -65,4 +67,5 @@ allTests =
   , test_MoreParser
   , test_JsonParser
   , test_Cheque
+  , test_Contravariant
   ]


### PR DESCRIPTION
add tests for `Contravariant`

they are all passed by my implementation
```haskell
instance Contravariant Predicate where
  (>$<) ::
    (b -> a)
    -> Predicate a
    -> Predicate b
  (>$<) f (Predicate a) = Predicate $ a . f

instance Contravariant Comparison where
  (>$<) ::
    (b -> a)
    -> Comparison a
    -> Comparison b
  (>$<) f (Comparison a) = Comparison $ \b1 b2 -> a (f b1) (f b2)

instance Contravariant (SwappedArrow t) where
  (>$<) ::
    (b -> a)
    -> SwappedArrow x a
    -> SwappedArrow x b
  (>$<) f (SwappedArrow g) = SwappedArrow (g . f)

(>$) ::
  Contravariant k =>
  a
  -> k a
  -> k b
(>$) a = (const a >$<)

```

```
PASSED: 'Contravariant.Predicate.even'
PASSED: 'Contravariant.Predicate.even length'
PASSED: 'Contravariant.Comparison.show'
PASSED: 'Contravariant.Comparison.id'
PASSED: 'Contravariant.Comparison.length'
PASSED: 'Contravariant.SwappedArrow.length'
PASSED: 'Contravariant.SwappedArrow.id'
PASSED: 'Contravariant.Ignore.Ignore input value, always odd'
PASSED: 'Contravariant.Ignore.Ignore input value, always even'
```