### PR TITLE
add Compose Test

### DIFF
--- a/src/Test/ComposeTest.hs
+++ b/src/Test/ComposeTest.hs
@@ -1,0 +1,63 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Test.ComposeTest (
+  -- * Tests
+    test_Compose
+  , functorTest
+  , applicativeTest
+  , contravariantTest
+
+  -- * Runner
+  , test
+  ) where
+
+import           Test.Framework  (TestTree, testCase, testGroup, test, (@?=), testProperty)
+
+import           Course.Core
+import           Course.List (length, List ((:.), Nil))
+import           Course.Compose (Compose (Compose))
+import           Course.Functor ((<$>))
+import           Course.Applicative (pure, (<*>))
+import           Course.Contravariant (Predicate (Predicate), (>$<), runPredicate)
+import           Course.ExactlyOne (ExactlyOne (ExactlyOne), runExactlyOne)
+import           Course.Optional (Optional (Full, Empty))
+
+runCompose :: Compose f g a -> f (g a)
+runCompose (Compose k) = k
+
+test_Compose :: TestTree
+test_Compose =
+  testGroup "Compose" [
+    functorTest
+  , applicativeTest
+  , contravariantTest
+  ]
+
+functorTest :: TestTree
+functorTest =
+  testGroup "Functor" [
+    testCase "ExactlyOne Full" $
+      (+1) <$> Compose (ExactlyOne (Full 2)) @?= Compose (ExactlyOne (Full 3))
+  , testCase "ExactlyOne Empty" $
+      (+1) <$> Compose (ExactlyOne Empty) @?= Compose (ExactlyOne Empty)
+  ]
+
+applicativeTest :: TestTree
+applicativeTest =
+  testGroup "Applicative" [
+    testCase "pure" $
+      pure 2 @?= Compose (ExactlyOne (Full 2))
+  , testCase "ExactlyOne Full" $
+      (+) <$> Compose (ExactlyOne (Full 1)) <*> Compose (ExactlyOne (Full 2)) @?=
+        Compose (ExactlyOne (Full 3))
+  ]
+
+contravariantTest :: TestTree
+contravariantTest =
+  testGroup "Contravariant" [
+    testCase "length even" $
+      runPredicate
+        (runExactlyOne (runCompose (length >$< Compose (ExactlyOne (Predicate even)))))
+        (1 :. 2 :. 3 :. 4 :. Nil) @?= True
+  ]

--- a/src/Test/ComposeTest.hs
+++ b/src/Test/ComposeTest.hs
@@ -12,7 +12,7 @@ module Test.ComposeTest (
   , test
   ) where
 
-import           Test.Framework  (TestTree, testCase, testGroup, test, (@?=), testProperty)
+import           Test.Framework  (TestTree, testCase, testGroup, test, (@?=))
 
 import           Course.Core
 import           Course.List (length, List ((:.), Nil))

--- a/src/Test/Loader.hs
+++ b/src/Test/Loader.hs
@@ -20,6 +20,7 @@ module Test.Loader
   , test_JsonParser
   , test_Cheque
   , test_Contravariant
+  , test_Compose
 
   , test
   , allTests
@@ -29,6 +30,7 @@ module Test.Loader
 import Test.ApplicativeTest (test_Applicative)
 import Test.ChequeTest (test_Cheque)
 import Test.ComonadTest (test_Comonad)
+import Test.ComposeTest (test_Compose)
 import Test.ContravariantTest (test_Contravariant)
 import Test.ExtendTest (test_Extend)
 import Test.FunctorTest (test_Functor)
@@ -68,4 +70,5 @@ allTests =
   , test_JsonParser
   , test_Cheque
   , test_Contravariant
+  , test_Compose
   ]


### PR DESCRIPTION
add tests for `Compose`

they are all passed by my implementation
```haskell
instance (Functor f, Functor g) =>
    Functor (Compose f g) where
  (<$>) :: (a -> b) -> Compose f g a -> Compose f g b
  (<$>) k (Compose fg) = Compose ((k <$>) <$> fg)

instance (Applicative f, Applicative g) =>
  Applicative (Compose f g) where
  pure :: a -> Compose f g a
  pure = Compose . pure . pure

  (<*>) :: Compose f g (a -> b) -> Compose f g a -> Compose f g b
  (<*>) (Compose f) (Compose g) = Compose (lift2 (<*>) f g)

instance (Functor f, Contravariant g) =>
  Contravariant (Compose f g) where
  (>$<) :: (b -> a) -> Compose f g a -> Compose f g b
  (>$<) k (Compose fg) = Compose ((k >$<) <$> fg)
```

```
PASSED: 'Compose.Functor.ExactlyOne Full'
PASSED: 'Compose.Functor.ExactlyOne Empty'
PASSED: 'Compose.Applicative.pure'
PASSED: 'Compose.Applicative.ExactlyOne Full'
PASSED: 'Compose.Contravariant.length even'
```